### PR TITLE
Implement stock recap SwiftUI app

### DIFF
--- a/TradingTools/ContentView.swift
+++ b/TradingTools/ContentView.swift
@@ -8,14 +8,23 @@
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var model = RecapModel()
+    
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        TabView {
+            StepEditor(title: "看新闻", text: $model.news)
+                .tabItem { Label("新闻", systemImage: "newspaper") }
+            StepEditor(title: "看大盘", text: $model.market)
+                .tabItem { Label("大盘", systemImage: "chart.line.uptrend.xyaxis") }
+            StepEditor(title: "看热点", text: $model.topic)
+                .tabItem { Label("热点", systemImage: "flame") }
+            StepEditor(title: "看持仓", text: $model.holdings)
+                .tabItem { Label("持仓", systemImage: "briefcase") }
+            StepEditor(title: "选股", text: $model.selection)
+                .tabItem { Label("选股", systemImage: "list.bullet.rectangle") }
+            StepEditor(title: "制定计划", text: $model.plan)
+                .tabItem { Label("计划", systemImage: "calendar") }
         }
-        .padding()
     }
 }
 

--- a/TradingTools/RecapModel.swift
+++ b/TradingTools/RecapModel.swift
@@ -1,0 +1,11 @@
+import Foundation
+import SwiftUI
+
+class RecapModel: ObservableObject {
+    @Published var news: String = ""
+    @Published var market: String = ""
+    @Published var topic: String = ""
+    @Published var holdings: String = ""
+    @Published var selection: String = ""
+    @Published var plan: String = ""
+}

--- a/TradingTools/StepEditor.swift
+++ b/TradingTools/StepEditor.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct StepEditor: View {
+    let title: String
+    @Binding var text: String
+    
+    var body: some View {
+        NavigationStack {
+            TextEditor(text: $text)
+                .padding()
+                .navigationTitle(title)
+        }
+    }
+}
+
+struct StepEditor_Previews: PreviewProvider {
+    static var previews: some View {
+        StepEditor(title: "示例", text: .constant(""))
+    }
+}


### PR DESCRIPTION
## Summary
- create model for capturing daily recap notes
- create reusable `StepEditor` view
- build a tabbed interface in `ContentView` for news, market, topics, holdings, selection, and planning

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683fd85ef07c8333b8c4a9a3f2bd795b