### PR TITLE
Implement basic trade plan management

### DIFF
--- a/TradingTools/ContentView.swift
+++ b/TradingTools/ContentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var model = RecapModel()
+    @StateObject private var planStore = TradePlanStore()
     
     var body: some View {
         TabView {
@@ -22,8 +23,12 @@ struct ContentView: View {
                 .tabItem { Label("持仓", systemImage: "briefcase") }
             StepEditor(title: "选股", text: $model.selection)
                 .tabItem { Label("选股", systemImage: "list.bullet.rectangle") }
-            StepEditor(title: "制定计划", text: $model.plan)
-                .tabItem { Label("计划", systemImage: "calendar") }
+
+            PlanListView(store: planStore)
+                .tabItem { Label("计划", systemImage: "list.bullet.clipboard") }
+
+            StepEditor(title: "复盘", text: $model.plan)
+                .tabItem { Label("复盘", systemImage: "calendar") }
         }
     }
 }

--- a/TradingTools/PlanDetailView.swift
+++ b/TradingTools/PlanDetailView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct PlanDetailView: View {
+    @Binding var plan: TradePlan
+
+    var body: some View {
+        Form {
+            Section(header: Text("基本信息")) {
+                TextField("品种", text: $plan.symbol)
+                Picker("方向", selection: $plan.direction) {
+                    ForEach(TradeDirection.allCases) { dir in
+                        Text(dir.rawValue).tag(dir)
+                    }
+                }
+                TextField("入场价", value: $plan.entryPrice, format: .number)
+                TextField("止损价", value: $plan.stopLoss, format: .number)
+                TextField("止盈价", value: $plan.takeProfit, format: .number)
+            }
+            Section(header: Text("备注")) {
+                TextField("备注", text: $plan.notes, axis: .vertical)
+            }
+            Section(header: Text("状态")) {
+                Picker("状态", selection: $plan.status) {
+                    ForEach(TradeStatus.allCases) { status in
+                        Text(status.rawValue).tag(status)
+                    }
+                }
+            }
+        }
+        .navigationTitle(plan.symbol)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+struct PlanDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanDetailView(plan: .constant(TradePlan(symbol: "TSLA", direction: .long, entryPrice: 100, stopLoss: 90, takeProfit: 120, notes: "")))
+    }
+}

--- a/TradingTools/PlanEditView.swift
+++ b/TradingTools/PlanEditView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct PlanEditView: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var store: TradePlanStore
+    @State private var symbol: String = ""
+    @State private var direction: TradeDirection = .long
+    @State private var entry: String = ""
+    @State private var stopLoss: String = ""
+    @State private var takeProfit: String = ""
+    @State private var notes: String = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("基本信息")) {
+                    TextField("品种", text: $symbol)
+                    Picker("方向", selection: $direction) {
+                        ForEach(TradeDirection.allCases) { dir in
+                            Text(dir.rawValue).tag(dir)
+                        }
+                    }
+                    TextField("入场价", text: $entry)
+                        .keyboardType(.decimalPad)
+                    TextField("止损价", text: $stopLoss)
+                        .keyboardType(.decimalPad)
+                    TextField("止盈价", text: $takeProfit)
+                        .keyboardType(.decimalPad)
+                }
+                Section(header: Text("备注")) {
+                    TextField("备注", text: $notes, axis: .vertical)
+                }
+            }
+            .navigationTitle("新计划")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存") { save() }
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func save() {
+        guard let entryP = Double(entry), let sl = Double(stopLoss), let tp = Double(takeProfit) else { return }
+        let plan = TradePlan(symbol: symbol, direction: direction, entryPrice: entryP, stopLoss: sl, takeProfit: tp, notes: notes)
+        store.add(plan)
+        dismiss()
+    }
+}
+
+struct PlanEditView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanEditView(store: TradePlanStore())
+    }
+}

--- a/TradingTools/PlanListView.swift
+++ b/TradingTools/PlanListView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct PlanListView: View {
+    @ObservedObject var store: TradePlanStore
+    @State private var showAdd = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(store.plans) { plan in
+                    NavigationLink(value: plan.id) {
+                        PlanRowView(plan: plan)
+                    }
+                }
+                .onDelete(perform: store.delete)
+            }
+            .navigationTitle("交易计划")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showAdd = true }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showAdd) {
+                PlanEditView(store: store)
+            }
+            .navigationDestination(for: UUID.self) { id in
+                if let index = store.plans.firstIndex(where: { $0.id == id }) {
+                    PlanDetailView(plan: $store.plans[index])
+                }
+            }
+        }
+    }
+}
+
+struct PlanListView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanListView(store: TradePlanStore())
+    }
+}

--- a/TradingTools/PlanRowView.swift
+++ b/TradingTools/PlanRowView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct PlanRowView: View {
+    let plan: TradePlan
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text(plan.symbol)
+                    .font(.headline)
+                Spacer()
+                Text(plan.status.rawValue)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Text("\(plan.direction.rawValue) 入场: \(plan.entryPrice, specifier: \"%.2f\")")
+                .font(.subheadline)
+        }
+    }
+}
+
+struct PlanRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanRowView(plan: TradePlan(symbol: "AAPL", direction: .long, entryPrice: 100, stopLoss: 90, takeProfit: 120, notes: ""))
+    }
+}

--- a/TradingTools/TradePlan.swift
+++ b/TradingTools/TradePlan.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum TradeDirection: String, Codable, CaseIterable, Identifiable {
+    case long = "多"
+    case short = "空"
+
+    var id: String { rawValue }
+}
+
+enum TradeStatus: String, Codable, CaseIterable, Identifiable {
+    case pending = "待执行"
+    case open = "已执行"
+    case closed = "已平仓"
+    case cancelled = "已取消"
+
+    var id: String { rawValue }
+}
+
+struct TradePlan: Identifiable, Codable {
+    var id: UUID = UUID()
+    var symbol: String
+    var direction: TradeDirection
+    var entryPrice: Double
+    var stopLoss: Double
+    var takeProfit: Double
+    var notes: String
+    var status: TradeStatus = .pending
+}

--- a/TradingTools/TradePlanStore.swift
+++ b/TradingTools/TradePlanStore.swift
@@ -1,0 +1,37 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class TradePlanStore: ObservableObject {
+    @Published var plans: [TradePlan] = []
+    private let fileURL: URL
+
+    init() {
+        let manager = FileManager.default
+        let url = manager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        self.fileURL = url.appendingPathComponent("plans.json")
+        load()
+    }
+
+    func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        if let items = try? JSONDecoder().decode([TradePlan].self, from: data) {
+            plans = items
+        }
+    }
+
+    func save() {
+        guard let data = try? JSONEncoder().encode(plans) else { return }
+        try? data.write(to: fileURL)
+    }
+
+    func add(_ plan: TradePlan) {
+        plans.append(plan)
+        save()
+    }
+
+    func delete(at offsets: IndexSet) {
+        plans.remove(atOffsets: offsets)
+        save()
+    }
+}


### PR DESCRIPTION
## Summary
- add trade plan data model and persistence
- create views for listing, editing and showing trade plans
- update main tab view to include new plan management section

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684014e83be48333b01307b773406af1