### PR TITLE
Adjust plan migration logic

### DIFF
--- a/TradingTools/PlanDetailView.swift
+++ b/TradingTools/PlanDetailView.swift
@@ -27,6 +27,7 @@ struct PlanDetailView: View {
         Form {
             Section(header: Text("基本信息")) {
                 TextField("品种", text: $plan.symbol)
+                TextField("策略", text: $plan.strategy)
                 Picker("方向", selection: $plan.direction) {
                     ForEach(TradeDirection.allCases) { dir in
                         Text(dir.rawValue).tag(dir)
@@ -34,14 +35,21 @@ struct PlanDetailView: View {
                 }
                 DatePicker("日期", selection: $plan.date, displayedComponents: .date)
                 DatePicker("操作时间", selection: $plan.actionTime, displayedComponents: .hourAndMinute)
-                TextField("入场价", value: $plan.entryPrice, format: .number)
-                TextField("止损价", value: $plan.stopLoss, format: .number)
+                TextField("入场价", value: Binding(get: { plan.entryPrice ?? 0 }, set: { plan.entryPrice = $0 }), format: .number)
+                TextField("止损价", value: Binding(get: { plan.stopLoss ?? 0 }, set: { plan.stopLoss = $0 }), format: .number)
+                TextField("止盈价", value: Binding(get: { plan.takeProfitPrice ?? 0 }, set: { plan.takeProfitPrice = $0 }), format: .number)
+                TextField("仓位", value: Binding(get: { plan.quantity ?? 0 }, set: { plan.quantity = $0 }), format: .number)
                 TextField("止盈条件", text: $plan.takeProfitCondition)
+                Picker("计划操作", selection: $plan.plannedAction) {
+                    ForEach(PlanAction.allCases) { ac in
+                        Text(ac.rawValue).tag(ac)
+                    }
+                }
             }
             Section(header: Text("备注")) {
                 TextField("备注", text: $plan.notes, axis: .vertical)
             }
-            Section(header: Text("状态")) {
+            Section(header: Text("今日操作")) {
                 Picker("状态", selection: $plan.status) {
                     ForEach(TradeStatus.allCases) { status in
                         Text(status.rawValue).tag(status)
@@ -97,7 +105,7 @@ struct PlanDetailView: View {
 
 struct PlanDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        PlanDetailView(plan: .constant(TradePlan(symbol: "TSLA", direction: .long, entryPrice: 100, stopLoss: 90, notes: "")))
+        PlanDetailView(plan: .constant(TradePlan(symbol: "TSLA", strategy: "", direction: .long, entryPrice: 100, stopLoss: 90, notes: "")))
             .environment(\.managedObjectContext, PersistenceController.shared.container.viewContext)
     }
 }

--- a/TradingTools/PlanEditView.swift
+++ b/TradingTools/PlanEditView.swift
@@ -4,11 +4,14 @@ struct PlanEditView: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject var store: TradePlanStore
     @State private var symbol: String = ""
+    @State private var strategy: String = ""
     @State private var direction: TradeDirection = .long
     @State private var entry: String = ""
     @State private var stopLoss: String = ""
+    @State private var quantity: String = ""
     @State private var takeProfit: String = ""
     @State private var actionTime: Date = Calendar.current.date(bySettingHour: 9, minute: 30, second: 0, of: .now) ?? .now
+    @State private var planned: PlanAction = .none
     @State private var notes: String = ""
     @State private var date: Date = Calendar.current.date(byAdding: .day, value: 1, to: .now) ?? .now
 
@@ -17,17 +20,27 @@ struct PlanEditView: View {
             Form {
                 Section(header: Text("基本信息")) {
                     TextField("品种", text: $symbol)
+                    TextField("策略", text: $strategy)
                     Picker("方向", selection: $direction) {
                         ForEach(TradeDirection.allCases) { dir in
                             Text(dir.rawValue).tag(dir)
                         }
                     }
                     DatePicker("日期", selection: $date, displayedComponents: .date)
-                    DatePicker("操作时间", selection: $actionTime, displayedComponents: .hourAndMinute)
-                    TextField("入场价", text: $entry)
-                        .keyboardType(.decimalPad)
-                    TextField("止损价", text: $stopLoss)
-                        .keyboardType(.decimalPad)
+                    Picker("计划操作", selection: $planned) {
+                        ForEach(PlanAction.allCases) { ac in
+                            Text(ac.rawValue).tag(ac)
+                        }
+                    }
+                    if planned == .build {
+                        DatePicker("操作时间", selection: $actionTime, displayedComponents: .hourAndMinute)
+                        TextField("入场价", text: $entry)
+                            .keyboardType(.decimalPad)
+                        TextField("止损价", text: $stopLoss)
+                            .keyboardType(.decimalPad)
+                        TextField("买入仓位", text: $quantity)
+                            .keyboardType(.decimalPad)
+                    }
                     TextField("止盈条件", text: $takeProfit)
                 }
                 Section(header: Text("备注")) {
@@ -47,14 +60,19 @@ struct PlanEditView: View {
     }
 
     private func save() {
-        guard let entryP = Double(entry), let sl = Double(stopLoss) else { return }
+        let entryP = Double(entry)
+        let sl = Double(stopLoss)
+        let qty = Double(quantity)
         let plan = TradePlan(symbol: symbol,
+                             strategy: strategy,
                              direction: direction,
                              date: date,
                              actionTime: actionTime,
+                             plannedAction: planned,
                              takeProfitCondition: takeProfit,
                              entryPrice: entryP,
                              stopLoss: sl,
+                             quantity: qty,
                              notes: notes)
         store.add(plan)
         dismiss()

--- a/TradingTools/PlanMigrationView.swift
+++ b/TradingTools/PlanMigrationView.swift
@@ -1,25 +1,80 @@
 import SwiftUI
 
 struct PlanMigrationView: View {
-    @Binding var plan: TradePlan
+    let plan: TradePlan
+    @ObservedObject var store: TradePlanStore
     var onComplete: () -> Void
+
+    @State private var todayAction: TradeStatus
+    @State private var plannedAction: PlanAction
+    @State private var entry: String
+    @State private var stopLoss: String
+    @State private var takeProfit: String
+    @State private var quantity: String
+    @State private var actionTime: Date
+    @State private var notes: String
+
+    init(plan: TradePlan, store: TradePlanStore, onComplete: @escaping () -> Void) {
+        self.plan = plan
+        self.store = store
+        self.onComplete = onComplete
+        _todayAction = State(initialValue: plan.plannedAction == .build ? .build : .none)
+        _plannedAction = State(initialValue: plan.plannedAction)
+        _entry = State(initialValue: plan.entryPrice.map { String($0) } ?? "")
+        _stopLoss = State(initialValue: plan.stopLoss.map { String($0) } ?? "")
+        _takeProfit = State(initialValue: plan.takeProfitPrice.map { String($0) } ?? "")
+        _quantity = State(initialValue: plan.quantity.map { String($0) } ?? "")
+        _actionTime = State(initialValue: plan.actionTime)
+        _notes = State(initialValue: plan.notes)
+    }
 
     var body: some View {
         NavigationStack {
             Form {
+                Section(header: Text("品种")) {
+                    Text(plan.symbol)
+                    Text(plan.strategy)
+                }
                 Section(header: Text("今日操作")) {
-                    Picker("状态", selection: $plan.status) {
+                    Picker("状态", selection: $todayAction) {
                         ForEach(TradeStatus.allCases) { st in
                             Text(st.rawValue).tag(st)
                         }
                     }
-                    if plan.status == .open {
-                        TextField("入场价", value: $plan.entryPrice, format: .number)
-                        TextField("止损价", value: $plan.stopLoss, format: .number)
+                    switch todayAction {
+                    case .build:
+                        TextField("入场价", text: $entry)
+                            .keyboardType(.decimalPad)
+                        TextField("止损价", text: $stopLoss)
+                            .keyboardType(.decimalPad)
+                        TextField("买入仓位", text: $quantity)
+                            .keyboardType(.decimalPad)
+                    case .partial:
+                        TextField("止盈价", text: $takeProfit)
+                            .keyboardType(.decimalPad)
+                        TextField("卖出仓位", text: $quantity)
+                            .keyboardType(.decimalPad)
+                    case .stopLoss:
+                        TextField("止损价", text: $stopLoss)
+                            .keyboardType(.decimalPad)
+                        TextField("卖出仓位", text: $quantity)
+                            .keyboardType(.decimalPad)
+                    default:
+                        EmptyView()
+                    }
+                }
+                Section(header: Text("计划操作")) {
+                    Picker("操作", selection: $plannedAction) {
+                        ForEach(PlanAction.allCases) { ac in
+                            Text(ac.rawValue).tag(ac)
+                        }
+                    }
+                    if plannedAction == .build {
+                        DatePicker("操作时间", selection: $actionTime, displayedComponents: .hourAndMinute)
                     }
                 }
                 Section(header: Text("备注")) {
-                    TextField("备注", text: $plan.notes)
+                    TextField("备注", text: $notes)
                 }
             }
             .navigationTitle("更新计划")
@@ -32,11 +87,29 @@ struct PlanMigrationView: View {
     }
 
     private func migrate() {
-        plan.date = Calendar.current.date(byAdding: .day, value: 1, to: plan.date) ?? plan.date
+        let nextDate = Calendar.current.date(byAdding: .day, value: 1, to: plan.date) ?? plan.date
+        let entryP = Double(entry)
+        let sl = Double(stopLoss)
+        let qty = Double(quantity)
+        let tp = Double(takeProfit)
+        let newPlan = TradePlan(symbol: plan.symbol,
+                               strategy: plan.strategy,
+                               direction: plan.direction,
+                               date: nextDate,
+                               actionTime: actionTime,
+                               plannedAction: plannedAction,
+                               takeProfitCondition: plan.takeProfitCondition,
+                               entryPrice: entryP,
+                               stopLoss: sl,
+                               takeProfitPrice: tp,
+                               quantity: qty,
+                               notes: notes,
+                               status: todayAction)
+        store.add(newPlan)
         onComplete()
     }
 }
 
 #Preview {
-    PlanMigrationView(plan: .constant(TradePlan(symbol: "AAPL", direction: .long, entryPrice: 10, stopLoss: 9, notes: ""))) {}
+    PlanMigrationView(plan: TradePlan(symbol: "AAPL", strategy: "", direction: .long, notes: ""), store: TradePlanStore()) {}
 }

--- a/TradingTools/PlanRowView.swift
+++ b/TradingTools/PlanRowView.swift
@@ -28,8 +28,12 @@ struct PlanRowView: View {
             HStack(spacing: 12) {
                 Text(plan.direction.rawValue)
                     .foregroundColor(plan.direction == .long ? .green : .red)
-                Text("入 \(String(format: "%.2f", plan.entryPrice))")
-                Text("止损 \(String(format: "%.2f", plan.stopLoss))")
+                if let e = plan.entryPrice {
+                    Text("入 \(String(format: "%.2f", e))")
+                }
+                if let sl = plan.stopLoss {
+                    Text("止损 \(String(format: "%.2f", sl))")
+                }
             }
             .font(.footnote)
             .foregroundColor(.secondary)
@@ -50,6 +54,6 @@ struct PlanRowView: View {
 
 struct PlanRowView_Previews: PreviewProvider {
     static var previews: some View {
-        PlanRowView(plan: TradePlan(symbol: "AAPL", direction: .long, entryPrice: 100, stopLoss: 90, notes: ""))
+        PlanRowView(plan: TradePlan(symbol: "AAPL", strategy: "", direction: .long, entryPrice: 100, stopLoss: 90, notes: ""))
     }
 }

--- a/TradingTools/RecordEditView.swift
+++ b/TradingTools/RecordEditView.swift
@@ -46,6 +46,6 @@ struct RecordEditView: View {
 }
 
 #Preview {
-    RecordEditView(plan: TradePlan(symbol: "AAPL", direction: .long, entryPrice: 10, stopLoss: 9, notes: ""))
+    RecordEditView(plan: TradePlan(symbol: "AAPL", strategy: "", direction: .long, entryPrice: 10, stopLoss: 9, notes: ""))
         .environment(\.managedObjectContext, PersistenceController.shared.container.viewContext)
 }

--- a/TradingTools/TradePlan.swift
+++ b/TradingTools/TradePlan.swift
@@ -8,10 +8,19 @@ enum TradeDirection: String, Codable, CaseIterable, Identifiable {
 }
 
 enum TradeStatus: String, Codable, CaseIterable, Identifiable {
-    case pending = "待执行"
-    case open = "已执行"
-    case closed = "已平仓"
-    case cancelled = "已取消"
+    case none = "无"
+    case build = "建仓"
+    case hold = "持有"
+    case partial = "部分止盈"
+    case stopLoss = "止损"
+
+    var id: String { rawValue }
+}
+
+enum PlanAction: String, Codable, CaseIterable, Identifiable {
+    case none = "无"
+    case build = "建仓"
+    case check = "检查止盈止损"
 
     var id: String { rawValue }
 }
@@ -19,68 +28,90 @@ enum TradeStatus: String, Codable, CaseIterable, Identifiable {
 struct TradePlan: Identifiable, Codable {
     var id: UUID = UUID()
     var symbol: String
+    var strategy: String = ""
     var direction: TradeDirection
     /// The date this plan is intended for
     var date: Date = .now
     /// Planned time to operate
     var actionTime: Date = .now
+    /// Next day's planned operation
+    var plannedAction: PlanAction = .none
     /// Condition to take profit
     var takeProfitCondition: String = ""
-    var entryPrice: Double
-    var stopLoss: Double
+    var entryPrice: Double?
+    var stopLoss: Double?
+    var takeProfitPrice: Double?
+    var quantity: Double?
     var notes: String
-    var status: TradeStatus = .pending
+    /// Today's actual operation
+    var status: TradeStatus = .none
 
     init(id: UUID = UUID(),
          symbol: String,
+         strategy: String = "",
          direction: TradeDirection,
          date: Date = .now,
          actionTime: Date = .now,
+         plannedAction: PlanAction = .none,
          takeProfitCondition: String = "",
-         entryPrice: Double,
-         stopLoss: Double,
+         entryPrice: Double? = nil,
+         stopLoss: Double? = nil,
+         takeProfitPrice: Double? = nil,
+         quantity: Double? = nil,
          notes: String,
-         status: TradeStatus = .pending) {
+         status: TradeStatus = .none) {
         self.id = id
         self.symbol = symbol
+        self.strategy = strategy
         self.direction = direction
         self.date = date
         self.actionTime = actionTime
+        self.plannedAction = plannedAction
         self.takeProfitCondition = takeProfitCondition
         self.entryPrice = entryPrice
         self.stopLoss = stopLoss
+        self.takeProfitPrice = takeProfitPrice
+        self.quantity = quantity
         self.notes = notes
         self.status = status
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, symbol, direction, date, actionTime, takeProfitCondition, entryPrice, stopLoss, notes, status
+        case id, symbol, strategy, direction, date, actionTime, plannedAction, takeProfitCondition, entryPrice, stopLoss, takeProfitPrice, quantity, notes, status
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
         symbol = try container.decode(String.self, forKey: .symbol)
+        strategy = try container.decodeIfPresent(String.self, forKey: .strategy) ?? ""
         direction = try container.decode(TradeDirection.self, forKey: .direction)
         date = try container.decodeIfPresent(Date.self, forKey: .date) ?? .now
         actionTime = try container.decodeIfPresent(Date.self, forKey: .actionTime) ?? .now
+        plannedAction = try container.decodeIfPresent(PlanAction.self, forKey: .plannedAction) ?? .none
         takeProfitCondition = try container.decodeIfPresent(String.self, forKey: .takeProfitCondition) ?? ""
-        entryPrice = try container.decode(Double.self, forKey: .entryPrice)
-        stopLoss = try container.decode(Double.self, forKey: .stopLoss)
+        entryPrice = try container.decodeIfPresent(Double.self, forKey: .entryPrice)
+        stopLoss = try container.decodeIfPresent(Double.self, forKey: .stopLoss)
+        takeProfitPrice = try container.decodeIfPresent(Double.self, forKey: .takeProfitPrice)
+        quantity = try container.decodeIfPresent(Double.self, forKey: .quantity)
         notes = try container.decodeIfPresent(String.self, forKey: .notes) ?? ""
-        status = try container.decodeIfPresent(TradeStatus.self, forKey: .status) ?? .pending
+        status = try container.decodeIfPresent(TradeStatus.self, forKey: .status) ?? .none
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(symbol, forKey: .symbol)
+        try container.encode(strategy, forKey: .strategy)
         try container.encode(direction, forKey: .direction)
         try container.encode(date, forKey: .date)
         try container.encode(actionTime, forKey: .actionTime)
+        try container.encode(plannedAction, forKey: .plannedAction)
         try container.encode(takeProfitCondition, forKey: .takeProfitCondition)
-        try container.encode(entryPrice, forKey: .entryPrice)
-        try container.encode(stopLoss, forKey: .stopLoss)
+        try container.encodeIfPresent(entryPrice, forKey: .entryPrice)
+        try container.encodeIfPresent(stopLoss, forKey: .stopLoss)
+        try container.encodeIfPresent(takeProfitPrice, forKey: .takeProfitPrice)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
         try container.encode(notes, forKey: .notes)
         try container.encode(status, forKey: .status)
     }


### PR DESCRIPTION
## Summary
- create new TradePlan on migration instead of modifying previous day
- support daily actions and planned actions
- simplify plan listing UI and update editors

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68403557434c8333870ac66760aa4b26